### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/codedocgen/codedocgen/code_doc_generator.py
+++ b/codedocgen/codedocgen/code_doc_generator.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     print("Error: Required packages not installed.")
     print("Please install the required packages using:")
-    print("pip install pyautogen requests")
+    print("pip install ag2 requests")
     sys.exit(1)
 
 # Configure logging

--- a/codedocgen/requirements.txt
+++ b/codedocgen/requirements.txt
@@ -1,4 +1,4 @@
-pyautogen>=0.2.0
+ag2>=0.2.0
 requests>=2.25.0
 questionary>=1.10.0
 pyyaml>=6.0

--- a/codedocgen/setup.py
+++ b/codedocgen/setup.py
@@ -21,7 +21,7 @@ setup(
     ],
     python_requires=">=3.7",
     install_requires=[
-        "pyautogen>=0.2.0",
+        "ag2>=0.2.0",
         "requests>=2.25.0",
         "questionary>=1.10.0",
         "pyyaml>=6.0",


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
